### PR TITLE
Added the ability to run the script directly

### DIFF
--- a/xsl_filter.rb
+++ b/xsl_filter.rb
@@ -1,4 +1,4 @@
-require 'restclient'
+require 'rest_client'
 require 'pry'
 require 'open-uri'
 require 'nokogiri'
@@ -120,8 +120,29 @@ module XslTranslatedTemplate
 end
 
 #find and replace all template variables with mt variables
-t = XslTemplate.new("")
-t.test
+
+# Only run the following code when this file is the main file being run
+# instead of having been required or loaded by another file
+if __FILE__==$0
+
+  case ARGV.length
+  when 0
+    puts "Usage:"
+    puts "Test -      ruby xsl_filter.rb [infile]"
+    puts "Transform - ruby xsl_filter.rb [infile] [outfile]"
+    exit 1
+  when 1
+    puts "Testing file: #{ARGV[0]}"
+    t = XslTemplate.new(ARGV[0])
+    t.test
+  when 2
+    t = XslTemplate.new(ARGV[0])
+    t.open
+    t.filter
+    t.save ARGV[1]
+  end
+
+end
 
 =begin
 jon stromer-galley: <xsl:value-of select=" concat('hi', 'ther'e) " />


### PR DESCRIPTION
At least for testing for now it was useful for me to wrap the test and filter methods so that they can be accessed from the command line. There is a check to verify it is not being included from another script.
- No parameters will print the usage
- One parameter will use the "test" method on the supplied file
- Two parameters, input file and output file will run the "filter" and "save" functions

Also fixed a a minor issue with the require rest client gem line. This was just to get the script to run. If this is the wrong require line or the wrong gem feel free to replace.
